### PR TITLE
Update /sdk page to use renamed dataset

### DIFF
--- a/docs/pages/sdk.mdx
+++ b/docs/pages/sdk.mdx
@@ -72,7 +72,7 @@ const embedbase = createClient(url, apiKey)
 ```ts
 // fetching data
 const data = await embedbase
-  .dataset('amazon-reviews')
+  .dataset('test-amazon-product-reviews')
   .search('best hot dogs accessories', { limit: 3 })
 
 console.log(data)
@@ -98,7 +98,7 @@ console.log(data)
 const data =
   await // embeddings are extremely good for retrieving unstructured data
   // in this example we store an unparsable html string
-  embedbase.dataset('amazon-reviews').add(`
+  embedbase.dataset('test-amazon-product-reviews').add(`
   <div>
     <span>Lightweight. Telescopic. Easy zipper case for storage. Didn't put in dishwasher. Still perfect after many uses.</span>
 `)
@@ -188,7 +188,7 @@ console.log(data)
 ```js
 const data =
   await
-  embedbase.dataset('amazon-reviews').add(`
+  embedbase.dataset('test-amazon-product-reviews').add(`
   <div>
     <span>Lightweight. Telescopic. Easy zipper case for storage. Didn't put in dishwasher. Still perfect after many uses.</span>
     // metadata can be anything you want that will appear in the search results later
@@ -210,7 +210,7 @@ console.log(data)
 ```js
 const data = await embedbase.datasets()
 console.log(data)
-// [{"datasetId": "amazon-reviews", "documentsCount": 2}]
+// [{"datasetId": "test-amazon-product-reviews", "documentsCount": 2}]
 ```
 
 ## Create a recommendation engine


### PR DESCRIPTION
## Description

I just executed the SDK tutorial and apparently, the default dataset was renamed from `amazon-reviews` to `test-amazon-product-reviews`.

It may save some people time figuring out why they receive an empty response 😃 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/different-ai/embedbase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/different-ai/embedbase/blob/main/CONTRIBUTING.md) guide.
<!-- - [ ] I've updated the code style using `make codestyle`. -->
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
