### PR TITLE
YamlModel is deprecated class

### DIFF
--- a/embedbase/settings.py
+++ b/embedbase/settings.py
@@ -2,7 +2,8 @@ from enum import Enum
 from functools import lru_cache
 import typing
 import os
-from pydantic_yaml import YamlModel
+from pydantic import BaseModel
+from pydantic_yaml import parse_yaml_file_as
 
 
 class VectorDatabaseEnum(str, Enum):
@@ -18,7 +19,7 @@ class EmbeddingProvider(str, Enum):
     COHERE = "cohere"
 
 
-class Settings(YamlModel):
+class Settings(BaseModel):
     openai_api_key: typing.Optional[str] = None
     openai_organization: typing.Optional[str] = None
     supabase_url: typing.Optional[str] = None
@@ -33,7 +34,7 @@ def get_settings_from_file(path: str = "config.yaml"):
     """
     Read settings from a file, only supports yaml for now
     """
-    settings = Settings.parse_file(path)
+    settings = parse_yaml_file_as(Settings, path)
 
     # TODO: move
     # if firebase, init firebase


### PR DESCRIPTION
## Description

YamlModel is a deprecated class in `pydantic_yaml`.

## Related Issue

https://github.com/different-ai/embedbase/issues/136

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/different-ai/embedbase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/different-ai/embedbase/blob/main/CONTRIBUTING.md) guide.
<!-- - [ ] I've updated the code style using `make codestyle`. -->
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
